### PR TITLE
fix: add null check to note description

### DIFF
--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -151,7 +151,7 @@ export default function Note(
                     if (!evt.altKey && ('ArrowUp' === evt.key || 'ArrowDown' === evt.key)) {
                         let pos = 0;
                         let currentRow = 0;
-                        const lines = props.note.description.split('\n');
+                        const lines = (props.note.description ?? '').split('\n');
 
                         lines
                             .forEach((p, i) => {


### PR DESCRIPTION
to avoid getting an error when trying to move up from the description to the title of the note